### PR TITLE
add requirement of wheel to make sure the fumction of dbist_wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ groundwork-sphinx-theme
 twine==4.0.2
 setuptools==68.2.2
 docker==6.1.3
+wheel==0.41.2


### PR DESCRIPTION
Running python setup.py sdist bdist_wheel with the error "error: invalid command 'bdist_wheel'" is usually due to a missing wheel module or it not being installed correctly